### PR TITLE
Set max for training extension

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -159,7 +159,8 @@
                 "javadoc_urls": ["https://github.com/qupath/qupath-extension-training/releases/download/v0.1.0-rc1/qupath-extension-training-0.1.0-rc1-javadoc.jar"],
                 "optional_dependency_urls": [],
                 "version_range": {
-                    "min": "v0.6.0-rc3"
+                    "min": "v0.6.0-rc3",
+                    "min": "v0.6.0-rc4"
                 }
             }
         ]


### PR DESCRIPTION
We bundle this in v0.6.0-rc5, so set the max to be rc4.