### PR TITLE
Add OMERO extension v0.2.4

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -73,6 +73,15 @@
         "starred": true,
         "releases": [
             {
+                "name": "v0.2.4",
+                "main_url": "https://github.com/qupath/qupath-extension-omero/releases/download/v0.2.4/qupath-extension-omero-0.2.4.jar",
+                "javadoc_urls": ["https://github.com/qupath/qupath-extension-omero/releases/download/v0.2.4/qupath-extension-omero-0.2.4-javadoc.jar"],
+                "optional_dependency_urls": ["https://github.com/ome/openmicroscopy/releases/download/v5.6.17/OMERO.java-5.6.17-ice36.zip"],
+                "version_range": {
+                    "min": "v0.6.0"
+                }
+            },
+            {
                 "name": "v0.2.3",
                 "main_url": "https://github.com/qupath/qupath-extension-omero/releases/download/v0.2.3/qupath-extension-omero-0.2.3.jar",
                 "javadoc_urls": ["https://github.com/qupath/qupath-extension-omero/releases/download/v0.2.3/qupath-extension-omero-0.2.3-javadoc.jar"],


### PR DESCRIPTION
Add OMERO extension [v0.2.4](https://github.com/qupath/qupath-extension-omero/releases/tag/v0.2.4)